### PR TITLE
Added Dapr and Tye support

### DIFF
--- a/DotNetOnContainerApps.FrontEnd/Program.cs
+++ b/DotNetOnContainerApps.FrontEnd/Program.cs
@@ -1,11 +1,21 @@
 var builder = WebApplication.CreateBuilder(args);
 
+// configure baseURL for Dapr sidecar
+var baseURL = (Environment.GetEnvironmentVariable("BASE_URL") ?? "http://localhost") + ":" + (Environment.GetEnvironmentVariable("DAPR_HTTP_PORT") ?? "3500"); //reconfigure code to make requests to Dapr sidecar
+
 // Add services to the container.
 builder.Services.AddRazorPages();
-builder.Services.AddHttpClient("catalog", (client) => client.BaseAddress = new Uri(builder.Configuration.GetValue<string>("CATALOG_API")));
-builder.Services.AddHttpClient("orders", (client) => client.BaseAddress = new Uri(builder.Configuration.GetValue<string>("ORDERS_API")));
+builder.Services.AddHttpClient("catalog", (client) => {
+    client.BaseAddress = new Uri(baseURL);
+    client.DefaultRequestHeaders.Add("dapr-app-id", "catalog");  //enable Dapr service invoke
+});
+builder.Services.AddHttpClient("orders", (client) => {
+    client.BaseAddress = new Uri(baseURL);
+    client.DefaultRequestHeaders.Add("dapr-app-id", "orders");  //enable Dapr service invoke
+});
 
 var app = builder.Build();
+app.Logger.LogInformation("Init: base URL set: " + baseURL);
 
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())

--- a/components/local/observability.yaml
+++ b/components/local/observability.yaml
@@ -1,0 +1,10 @@
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: daprConfig
+  namespace: default
+spec:
+  tracing:
+    samplingRate: "1"
+    zipkin:
+      endpointAddress: "http://localhost:9411/api/v2/spans"

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,7 @@ This repository contains a simple scenario built to demonstrate how ASP.NET Core
 * Catalog API - this is an ASP.NET minimal API project with one endpoint. 
 * Orders API - this is an ASP.NET minimal API project with one endpoint. 
 * UI - an ASP.NET Blazor Server app that calls out to both the Catalog and Orders API and renders their status.
+* ```tye.yaml```  - this file defines microservices that can be run easily on local development machine using `tye run` command
 * ```deploy``` folder - this folder contains a series of [Azure Bicep](http://aka.ms/bicep) templates that can be used to create the application and deploy it.
 * ```setup.ps1``` - this file is a one-stop way for you to deploy the app to your own Azure subscription so you can try the scenario. 
 
@@ -15,13 +16,17 @@ This repository contains a simple scenario built to demonstrate how ASP.NET Core
 * An Azure subscription
 * Docker
 * PowerShell *(GitHub Actions will replace this prerequisite soon)*
+* [Dapr](https://docs.dapr.io/getting-started/install-dapr-cli/)
+* [Tye](https://github.com/dotnet/tye/blob/main/docs/getting_started.md) (optional, recommended)
 
 ## Setup
 
 1. Clone this repository.
-2. Sign in to your Azure subscription using the `az login` command.
-3. If you have more than 1 Azure subscription, make sure you're targeting the *right* Azure subscription by using the `az account show` and `az account set -s <subscription-id>` commands.
-4. From the root of this repository, run `./setup.ps1`. 
+2. From root of this repo, run on local machine with `tye run`.  Test url is http://localhost:5213.  Tye dasbboard is http://localhost:8000.  
+3. View Zipkin observability and tracing on http://localhost:9411 
+4. Sign in to your Azure subscription using the `az login` command.
+5. If you have more than 1 Azure subscription, make sure you're targeting the *right* Azure subscription by using the `az account show` and `az account set -s <subscription-id>` commands.
+6. From the root of this repo, run `./setup.ps1`. 
 
 ## Topology diagram
 

--- a/tye.yaml
+++ b/tye.yaml
@@ -1,0 +1,26 @@
+name: dotnet-containerapp-sample
+
+services:
+- name: orders
+  executable: dapr
+  args: run --app-id orders --app-port 5001 -- dotnet run --project ./DotNetOnContainerApps.APIs.Orders.csproj --urls "http://localhost:5001"
+  workingDirectory: ./DotNetOnContainerApps.APIs.Orders/
+  bindings: # optional array of bindings (ports, connection strings)
+  - port: 5001 # number port of the binding
+    protocol: http
+
+- name: catalog
+  executable: dapr
+  args: run --app-id catalog --app-port 5002 -- dotnet run --project ./DotNetOnContainerApps.APIs.Catalog.csproj --urls "http://localhost:5002"
+  workingDirectory: ./DotNetOnContainerApps.APIs.Catalog/
+  bindings: # optional array of bindings (ports, connection strings)
+  - port: 5002 # number port of the binding
+    protocol: http
+  
+- name: frontend
+  executable: dapr
+  args: run --app-id frontend --app-port 5213 -- dotnet run --project ./DotNetOnContainerApps.FrontEnd.csproj --urls "http://localhost:5213"
+  workingDirectory: ./DotNetOnContainerApps.FrontEnd/
+  bindings: # optional array of bindings (ports, connection strings)
+  - port: 5213 # number port of the binding
+    protocol: http


### PR DESCRIPTION
- Enabled Dapr service invoke by adding HTTP headers to outbound calls to `orders` and `catalog`.  This enables things like service discovery, mTLS, and Zipkin tracing
- Enabled `tye run` for rapid local development inner loop experience
- Updated Readme 